### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/framework/gv-file-helpers.c
+++ b/src/framework/gv-file-helpers.c
@@ -17,6 +17,7 @@
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <sys/stat.h>
 #include <stdlib.h>
 #include <string.h>
 #include <fcntl.h>


### PR DESCRIPTION
Fix error 'S_IRWXU' undeclared.
Clang log:

framework/gv-file-helpers.c:99:39: error: 'S_IRWXU' undeclared (first use in this function)
   created = g_mkdir_with_parents(dir, S_IRWXU);
                                       ^
framework/gv-file-helpers.c:99:39: note: each undeclared identifier is reported only once for each function it appears in
framework/gv-file-helpers.c: In function 'gv_get_user_config_dir':
framework/gv-file-helpers.c:120:39: error: 'S_IRWXU' undeclared (first use in this function)
   created = g_mkdir_with_parents(dir, S_IRWXU);
                                       ^
gmake[2]: *** [Makefile:974: framework/goodvibes-gv-file-helpers.o] Error 1